### PR TITLE
Fix script import errors for client and server modules

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -1,5 +1,17 @@
-from .core.agent import MonitoringAgent
-from .gui.tray_app import MonitoringApp
+"""Entry point for launching the monitoring agent GUI."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Support running as ``python client/main.py`` by ensuring the repository root
+# is on ``sys.path`` and then using absolute imports.
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime convenience
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from client.core.agent import MonitoringAgent
+from client.gui.tray_app import MonitoringApp
 
 
 def main() -> None:  # pragma: no cover - integration

--- a/server/app.py
+++ b/server/app.py
@@ -1,11 +1,26 @@
+"""Flask application entry point for the monitoring server."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
 from flask import Flask
-from .config.server_config import ServerConfig
-from .models import db
-from .api.agents import agents_bp
-from .api.hardware import hardware_bp
-from .api.software import software_bp
-from .api.statistics import statistics_bp
-from .api.search import search_bp
+
+# When this file is executed directly (e.g. ``python server/app.py``) the
+# package context is not set, causing relative imports to fail. To support both
+# direct execution and package imports we ensure the repository root is on the
+# module search path and then use absolute imports.
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime convenience
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from server.config.server_config import ServerConfig
+from server.models import db
+from server.api.agents import agents_bp
+from server.api.hardware import hardware_bp
+from server.api.software import software_bp
+from server.api.statistics import statistics_bp
+from server.api.search import search_bp
 
 
 def create_app(config: ServerConfig | None = None) -> Flask:


### PR DESCRIPTION
## Summary
- allow server app to be executed directly by adding sys.path fix and using absolute imports
- enable running client main script directly in the same way

## Testing
- `pytest`
- `python server/app.py -c 'import sys'`


------
https://chatgpt.com/codex/tasks/task_e_68b19f6490d88331b15cb7bf6011d2a5