### PR TITLE
Serve dashboard via root route

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from flask import Flask
+from flask import Flask, render_template
 
 # When this file is executed directly (e.g. ``python server/app.py``) the
 # package context is not set, causing relative imports to fail. To support both
@@ -37,6 +37,12 @@ def create_app(config: ServerConfig | None = None) -> Flask:
     app.register_blueprint(software_bp)
     app.register_blueprint(statistics_bp)
     app.register_blueprint(search_bp)
+    
+    @app.route("/")
+    @app.route("/dashboard")
+    def dashboard():
+        """Render the main dashboard page."""
+        return render_template("dashboard.html")
     return app
 
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -11,3 +11,11 @@ def test_app_factory():
     client = app.test_client()
     resp = client.get('/api/hardware/')
     assert resp.status_code == 200
+
+
+def test_dashboard_route():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'System Monitor' in resp.data


### PR DESCRIPTION
## Summary
- render dashboard template on `/` and `/dashboard`
- add test covering dashboard route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a1b213e083318f12b2ced56543a5