### PR TITLE
Ensure settings window displays in client

### DIFF
--- a/client/gui/settings_window.py
+++ b/client/gui/settings_window.py
@@ -7,6 +7,11 @@ class SettingsWindow(tk.Toplevel):
     """Simple configuration dialog allowing modification of the server URL."""
 
     def __init__(self, master=None, config: ClientConfig | None = None):
+        self._root: tk.Tk | None = None
+        if master is None:
+            self._root = tk.Tk()
+            self._root.withdraw()
+            master = self._root
         super().__init__(master)
         self.title("Client Settings")
         self.resizable(False, False)
@@ -15,8 +20,15 @@ class SettingsWindow(tk.Toplevel):
         self.url_var = tk.StringVar(value=self.config_obj.server_url)
         ttk.Entry(self, textvariable=self.url_var, width=40).grid(row=0, column=1, padx=5, pady=5)
         ttk.Button(self, text="Save", command=self._save).grid(row=1, column=0, columnspan=2, pady=10)
+        self.protocol("WM_DELETE_WINDOW", self._close)
 
     def _save(self) -> None:
         self.config_obj.server_url = self.url_var.get()
         self.config_obj.save()
-        self.destroy()
+        self._close()
+
+    def _close(self) -> None:
+        if self._root is not None:
+            self._root.destroy()
+        else:
+            self.destroy()

--- a/client/gui/tray_app.py
+++ b/client/gui/tray_app.py
@@ -21,7 +21,11 @@ class MonitoringApp:
         )
 
     def open_settings(self):  # pragma: no cover - GUI
-        SettingsWindow()
+        def _run() -> None:
+            window = SettingsWindow()
+            window.mainloop()
+
+        threading.Thread(target=_run, daemon=True).start()
 
     def stop(self):  # pragma: no cover - GUI
         self.icon.stop()


### PR DESCRIPTION
## Summary
- ensure `SettingsWindow` creates and cleans up its own Tk root when opened standalone
- launch settings dialog on a background thread so Tk main loop runs without blocking the tray icon

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a578434c8331a24207161dfa3174