### PR TITLE
Add agents history endpoint

### DIFF
--- a/server/api/agents.py
+++ b/server/api/agents.py
@@ -26,6 +26,13 @@ def monitoring_data():
     return jsonify({'status': 'ok'})
 
 
+@agents_bp.route('/history', methods=['GET'])
+def get_agents_history():
+    """Return stored monitoring data for all agents."""
+    agents = _data_service.get_agents_history()
+    return jsonify({'agents': agents})
+
+
 @agents_bp.route('/service-tag/<service_tag>', methods=['GET'])
 def get_agent_by_service_tag(service_tag):
     agent = _agent_service.get_by_service_tag(service_tag)

--- a/server/services/data_service.py
+++ b/server/services/data_service.py
@@ -29,3 +29,52 @@ class DataService:
             )
             db.session.add(record)
         db.session.commit()
+
+    def get_agents_history(self) -> list[dict]:
+        """Return aggregated monitoring data for all agents."""
+        agents = Agent.query.all()
+        results: list[dict] = []
+        for agent in agents:
+            office_record = (
+                OfficeRecord.query.filter_by(agent_id=agent.agent_id)
+                .order_by(OfficeRecord.recorded_at.desc())
+                .first()
+            )
+            backup_record = (
+                BackupRecord.query.filter_by(agent_id=agent.agent_id)
+                .order_by(BackupRecord.recorded_at.desc())
+                .first()
+            )
+            results.append(
+                {
+                    "agent_id": agent.agent_id,
+                    "hostname": agent.hostname,
+                    "ip_address": agent.ip_address,
+                    "operating_system": agent.operating_system,
+                    "last_seen": agent.last_seen.isoformat() if agent.last_seen else None,
+                    "registered_at": agent.last_seen.isoformat() if agent.last_seen else None,
+                    "office": self._office_to_dict(office_record),
+                    "backup": self._backup_to_dict(backup_record),
+                }
+            )
+        return results
+
+    @staticmethod
+    def _office_to_dict(record: OfficeRecord | None) -> dict | None:
+        if not record:
+            return None
+        return {
+            "installed": record.is_installed,
+            "version": record.version,
+            "activation_status": record.activation_status,
+        }
+
+    @staticmethod
+    def _backup_to_dict(record: BackupRecord | None) -> dict | None:
+        if not record:
+            return None
+        return {
+            "status": record.backup_status,
+            "location": record.backup_location,
+            "last_backup": record.last_backup_date.isoformat() if record.last_backup_date else None,
+        }

--- a/tests/server/test_agents_history_endpoint.py
+++ b/tests/server/test_agents_history_endpoint.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from server.app import create_app
+from server.config.server_config import ServerConfig
+
+
+def create_test_app():
+    return create_app(ServerConfig(database_uri="sqlite:///:memory:"))
+
+
+def test_agents_history_endpoint():
+    app = create_test_app()
+    client = app.test_client()
+
+    register_payload = {
+        "agent_id": "AGENT1",
+        "hostname": "HOST1",
+    }
+    client.post("/api/agents/register", json=register_payload)
+
+    monitoring_payload = {
+        "system": {"agent_id": "AGENT1"},
+        "backup": {
+            "status": "found",
+            "backup_location": "/data/backup",
+        },
+    }
+    client.post("/api/agents/monitoring-data", json=monitoring_payload)
+
+    resp = client.get("/api/agents/history")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "agents" in data
+    assert len(data["agents"]) == 1
+    agent = data["agents"][0]
+    assert agent["agent_id"] == "AGENT1"
+    assert agent["backup"]["status"] == "found"


### PR DESCRIPTION
## Summary
- expose `/api/agents/history` to retrieve stored monitoring info
- aggregate backup and office records for all agents
- test agents history endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a7a06f1c8331bbfaf992ae9a59a7